### PR TITLE
Remove name from container.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,6 @@ version: '2'
 services:
   postgres:
     image: sameersbn/postgresql
-    container_name: pgsql_template
     ports:
     - "5432:5432"
     environment:


### PR DESCRIPTION
- This will give conflicts when using the same boilerplate multiple
times on the same machine